### PR TITLE
prevent last line comment

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,11 +19,11 @@ module.exports = function(content, file, conf){
                 .split('${id}').join(file.getId());
         } else if(type === 'amd') {
             if(!/^\s*define\s*\(/.test(content)){
-                content = 'define(\'' + file.getId() + '\', function(require, exports, module){ ' + content + ' });';
+                content = 'define(\'' + file.getId() + '\', function(require, exports, module){ ' + content + ' \r\n});';
             }
         } else {
             if(!/^\s*(?:[!(]\s*|void\s+)function\(/.test(content)){
-                content = '!function(){try{ ' + content + ' }catch(e){}}();';
+                content = '!function(){try{ ' + content + ' \r\n}catch(e){}}();';
             }
         }
     }


### PR DESCRIPTION
当脚本以注释结尾时，会出现花括号闭合错误

```javascript
var a = 1;
// end
```

```javascript
define('gogo:widget/bb.js', function(require, exports, module){var a = 1;
// end });
```